### PR TITLE
use awstats.conf config file

### DIFF
--- a/providers/domain_statistics.rb
+++ b/providers/domain_statistics.rb
@@ -48,7 +48,7 @@ action :add do
     mailto new_resource.cron_contact
   end
 
-  cookbook_file "/etc/apache2/conf.d/awstats" do
+  cookbook_file "/etc/apache2/conf.d/awstats.conf" do
     source "awstats"
     cookbook "awstats"
 


### PR DESCRIPTION
This is necessary on Ubuntu installations as apache on Ubuntu will include `/etc/apache2/conf.d/*.conf` by default:

```
Include /etc/apache2/conf.d/*.conf
```
