### PR TITLE
chef 12.x requires name attribute in metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,8 @@ maintainer_email "mike@fooforge.com"
 license          "Apache 2.0"
 description      "Installs awstats and provides an LWRP for creating domain-specific statistics"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.2"
+version          "0.2.3"
+name             "awstats"
 
 depends          "apache2"
 depends          "htpasswd"


### PR DESCRIPTION
Chef will file if the name attribute is not set in a cookbook's metadata.
